### PR TITLE
Updated to Support Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: './dist/index.js'


### PR DESCRIPTION
- Fixes #10 

Updated the action configuration to run  node116 rather than 12.

*Note* I have not fully tested the update, but it appears that is all that is needed, and the code running shouldn't really change.